### PR TITLE
Update 21008.txt

### DIFF
--- a/sutraani/vasu_english/21008.txt
+++ b/sutraani/vasu_english/21008.txt
@@ -1,4 +1,4 @@
 The indeclinable word यावत् when it signifies limitation, is invariably compounded with a word ending in a case-affix which is in construction with it, and the compound so formed is called अव्ययीभाव।
-The word अवधारण means accurate ascertainment, restriction or limitation. As, यावदमत्रं ब्राह्मणानामन्त्रयस्व invite so many <i>Bráhmanas</i> only and not more as there are pots': i.e., if there are five pots then invite five <i>Bráhmans</i>; if six pots, then invite six <i>Bráhmans</i>. 
+The word अवधारण means accurate ascertainment, restriction or limitation. As, यावदमत्रं ब्राह्मणानामामन्त्रयस्व invite so many <i>Bráhmanas</i> only and not more as there are pots': i.e., if there are five pots then invite five <i>Bráhmans</i>; if six pots, then invite six <i>Bráhmans</i>. 
 
 Why do we say 'when meaning limitation'? Observe यावद्दत्तं तावत् भुक्तम् 'I ate so long as it was given to me,' i.e. I do not know for certainty how much I have eaten.


### PR DESCRIPTION
This change attempts to correct the error in the original text itself. Original: यावदमत्रं ब्राह्मणानामन्त्रयस्व।  Padachcheda for this would be यावद् अमत्रं ब्राह्मणानाम् अन्त्रयस्व।  अन्त्रयस्व is not a valid form and from the explanation provided in english, it can be understood that it should be आमन्त्रयस्व which makes the sentence, यावदमत्रं ब्राह्मणानामामन्त्रयस्व।